### PR TITLE
Pass diff vectors on swipes are detected

### DIFF
--- a/EventListenerGesture.cpp
+++ b/EventListenerGesture.cpp
@@ -87,7 +87,7 @@ bool EventListenerGesture::init()
         if(swipeDirection != SwipeDirection::NONE)
         {
             _gestureType = GestureType::SWIPE;
-            if(onSwipe) onSwipe(swipeDirection);
+            if(onSwipe) onSwipe(swipeDirection, Vec2(xDiff, yDiff));
         }
     };
 

--- a/EventListenerGesture.h
+++ b/EventListenerGesture.h
@@ -45,7 +45,7 @@ public:
     std::function<void(cocos2d::Vec2)> onTap;
     std::function<void(cocos2d::Vec2)> onLongTapBegan;
     std::function<void(cocos2d::Vec2)> onLongTapEnded;
-    std::function<void(SwipeDirection)> onSwipe;
+    std::function<void(SwipeDirection, cocos2d::Vec2)> onSwipe;
 
 protected:
     EventListenerGesture();


### PR DESCRIPTION
When swipe gesture was detected, we couldn't get diff vectors.

This PR make it to know diff vectors in callback functions.
